### PR TITLE
multi-page viewer support 实现修改

### DIFF
--- a/xeHentai/core.py
+++ b/xeHentai/core.py
@@ -248,14 +248,13 @@ class xeHentai(object):
                             lambda x: task.set_fail(x))
                         if task.failcode:
                             break
-                else:
-                    if task.meta['finished'] < task.meta['total']:
-                        # use multipage viewer
-                        r = req.request("GET",
-                            task.mpv_url(),
-                            filters.flt_pageurl_mpv,
-                            lambda x: task.queue_wrapper(task.page_q.put, url = x),
-                            lambda x: task.set_fail(x))
+                elif task.meta['finished'] < task.meta['total']:
+                    # use multipage viewer
+                    r = req.request("GET",
+                        task.mpv_url(),
+                        filters.flt_pageurl_mpv,
+                        lambda x: task.queue_wrapper(task.page_q.put, url = x),
+                        lambda x: task.set_fail(x))
             elif task.state == TASK_STATE_SCAN_IMG:
                 # print here so that see it after we can join former threads
                 self.logger.info(i18n.TASK_TITLE % (

--- a/xeHentai/core.py
+++ b/xeHentai/core.py
@@ -238,23 +238,24 @@ class xeHentai(object):
                 task.scan_downloaded()
                 if task.state == TASK_STATE_FINISHED:
                     continue
-                for x in range(0,
-                    int(math.ceil(1.0 * task.meta['total'] / int(task.meta['thumbnail_cnt'])))):
-                    r = req.request("GET",
-                        "%s/?p=%d" % (task.url, x),
-                        filters.flt_pageurl,
-                        lambda x: task.queue_wrapper(task.page_q.put, url = x),
-                        lambda x: task.set_fail(x))
-                    if task.failcode:
-                        break
-                if not task.failcode and \
-                    task.meta['finished'] < task.meta['total'] and task.page_q.empty():
-                    # try multipage viewer
-                    r = req.request("GET",
-                        task.mpv_url(),
-                        filters.flt_pageurl_mpv,
-                        lambda x: task.queue_wrapper(task.page_q.put, url = x),
-                        lambda x: task.set_fail(x))
+                if not task.meta['use_multipage_viewer']:
+                    for x in range(0,
+                        int(math.ceil(1.0 * task.meta['total'] / int(task.meta['thumbnail_cnt'])))):
+                        r = req.request("GET",
+                            "%s/?p=%d" % (task.url, x),
+                            filters.flt_pageurl,
+                            lambda x: task.queue_wrapper(task.page_q.put, url = x),
+                            lambda x: task.set_fail(x))
+                        if task.failcode:
+                            break
+                else:
+                    if task.meta['finished'] < task.meta['total']:
+                        # use multipage viewer
+                        r = req.request("GET",
+                            task.mpv_url(),
+                            filters.flt_pageurl_mpv,
+                            lambda x: task.queue_wrapper(task.page_q.put, url = x),
+                            lambda x: task.set_fail(x))
             elif task.state == TASK_STATE_SCAN_IMG:
                 # print here so that see it after we can join former threads
                 self.logger.info(i18n.TASK_TITLE % (

--- a/xeHentai/filters.py
+++ b/xeHentai/filters.py
@@ -43,7 +43,6 @@ def flt_metadata(r, suc, fail):
         fail(ERR_IP_BANNED)
         return re.findall("The ban expires in (.+)", r.text)[0]
     meta = {}
-    # print(r.text)
     # sample_hash = re.findall('<a href="%s/./([a-f0-9]{10})/\d+\-\d+"><img' % RESTR_SITE, r.text)
     # meta['sample_hash'] = sample_hash
     # meta['resampled'] = {}
@@ -64,9 +63,9 @@ def flt_metadata(r, suc, fail):
             '<a href="(%s/mpv/(\d+)/[a-f0-9]{10})/#page\d+"><img alt="\d+" title="Page' % RESTR_SITE,
             r.text)
     if mpv_urls:
-        meta['use_multipage_viewer'] = 1
+        meta['use_multipage_viewer'] = True
     else:
-        meta['use_multipage_viewer'] = 0
+        meta['use_multipage_viewer'] = False
 
     suc(meta)
     # _ = re.findall(

--- a/xeHentai/filters.py
+++ b/xeHentai/filters.py
@@ -59,6 +59,15 @@ def flt_metadata(r, suc, fail):
     _ = re.findall("Showing (\d+) \- (\d+) of ([\d,]+) images", r.text)[0]
     meta['thumbnail_cnt'] = int(_[1]) - int(_[0]) + 1
 
+    # check multi page viewer status in order to call proper flt_pageurl
+    mpv_urls = re.findall(
+            '<a href="(%s/mpv/(\d+)/[a-f0-9]{10})/#page\d+"><img alt="\d+" title="Page' % RESTR_SITE,
+            r.text)
+    if mpv_urls:
+        meta['use_multipage_viewer'] = 1
+    else:
+        meta['use_multipage_viewer'] = 0
+
     suc(meta)
     # _ = re.findall(
     #    '%s/[^/]+/(\d+)/[^/]+/\?p=\d*" onclick="return false"(.*?)</a>' % RESTR_SITE,
@@ -102,17 +111,7 @@ def flt_pageurl(r, suc, fail):
         '<a href="(%s/./[a-f0-9]{10}/\d+\-\d+)"><img alt="\d+" title="Page' % RESTR_SITE,
         r.text)
     if not picpage:
-        # do we get a multipage viewer?
-        # if so, simply exit and don't set task to fail
-        # When gallery page>0, re'#page\d' will not match any result for #page starting from 21 or other number
-        # So I change it to '#page\d+'
-        # And I think set a certain error code to break loop, then try mpv immediately can make program more efficient
-        picpage = re.findall(
-            '<a href="(%s/mpv/(\d+)/[a-f0-9]{10})/#page\d+"><img alt="\d+" title="Page' % RESTR_SITE,
-            r.text)
-        if not picpage:
-            fail(ERR_NO_PAGEURL_FOUND)
-        return
+        fail(ERR_NO_PAGEURL_FOUND)
     for p in picpage:
         suc(p)
 

--- a/xeHentai/filters.py
+++ b/xeHentai/filters.py
@@ -104,8 +104,11 @@ def flt_pageurl(r, suc, fail):
     if not picpage:
         # do we get a multipage viewer?
         # if so, simply exit and don't set task to fail
+        # When gallery page>0, re'#page\d' will not match any result for #page starting from 21 or other number
+        # So I change it to '#page\d+'
+        # And I think set a certain error code to break loop, then try mpv immediately can make program more efficient
         picpage = re.findall(
-            '<a href="(%s/mpv/(\d+)/[a-f0-9]{10})/#page\d"><img alt="\d+" title="Page' % RESTR_SITE,
+            '<a href="(%s/mpv/(\d+)/[a-f0-9]{10})/#page\d+"><img alt="\d+" title="Page' % RESTR_SITE,
             r.text)
         if not picpage:
             fail(ERR_NO_PAGEURL_FOUND)


### PR DESCRIPTION
之前dev版本在flt_pageurl中使用
picpage = re.findall(
            \'<a href='"(%s/mpv/(\d+)/[a-f0-9]{10})/#page\d\"><img alt="\d+" title="Page' % RESTR_SITE,
            r.text)
匹配mpv的页面，试图跳过对画廊每一页的flt_pageurl fail函数。
但是re'#page\d'会在画廊第二页开始失效，因为第二页起url的#page已不止一位。导致后续的flt_pageurl_mpv无法顺利运行。
即使改为re'#page\d+'，在下载画廊页数较多的单行本或者cg集时也会产生大量无意义访问。

目前改为在flt_metadata中直接判断mpv使用情况，供后续选择合适的处理方法。